### PR TITLE
fix: stop first-party crashes on Safari 12 and YouTube related parse

### DIFF
--- a/apps/api/src/modules/youtube/fetch-related-page.ts
+++ b/apps/api/src/modules/youtube/fetch-related-page.ts
@@ -2,6 +2,7 @@ import { BaseVideoParser, Client, SearchResult, type VideoCompact } from 'youtub
 
 import { extractRendererMetadata, type RendererMetadataMaps } from './renderer-metadata';
 import { postInnertube } from './innertube-post';
+import { captureRelatedParseFailure, safeParseRelated } from './safe-parse-related';
 import { asYoutubeRawData } from './youtubei-raw-data';
 
 const NEXT_ENDPOINT = '/youtubei/v1/next';
@@ -20,8 +21,14 @@ export async function fetchRelatedContinuationPage(
     const response = await postInnertube(client, NEXT_ENDPOINT, { continuation });
     const rawData = asYoutubeRawData(response.data);
     const metadata = extractRendererMetadata(rawData);
-    const items = BaseVideoParser.parseRelated(rawData, client) as VideoCompact[];
-    const nextContinuation = BaseVideoParser.parseContinuation(rawData);
+    const items = safeParseRelated(rawData, client);
+    let nextContinuation: string | null | undefined;
+    try {
+        nextContinuation = BaseVideoParser.parseContinuation(rawData);
+    } catch (error) {
+        captureRelatedParseFailure(error);
+        nextContinuation = undefined;
+    }
 
     return {
         items,

--- a/apps/api/src/modules/youtube/fetch-related-page.ts
+++ b/apps/api/src/modules/youtube/fetch-related-page.ts
@@ -1,8 +1,8 @@
-import { BaseVideoParser, Client, SearchResult, type VideoCompact } from 'youtubei';
+import { Client, SearchResult, type VideoCompact } from 'youtubei';
 
 import { extractRendererMetadata, type RendererMetadataMaps } from './renderer-metadata';
 import { postInnertube } from './innertube-post';
-import { captureRelatedParseFailure, safeParseRelated } from './safe-parse-related';
+import { safeParseContinuation, safeParseRelated } from './safe-parse-related';
 import { asYoutubeRawData } from './youtubei-raw-data';
 
 const NEXT_ENDPOINT = '/youtubei/v1/next';
@@ -22,13 +22,7 @@ export async function fetchRelatedContinuationPage(
     const rawData = asYoutubeRawData(response.data);
     const metadata = extractRendererMetadata(rawData);
     const items = safeParseRelated(rawData, client);
-    let nextContinuation: string | null | undefined;
-    try {
-        nextContinuation = BaseVideoParser.parseContinuation(rawData);
-    } catch (error) {
-        captureRelatedParseFailure(error);
-        nextContinuation = undefined;
-    }
+    const nextContinuation = safeParseContinuation(rawData);
 
     return {
         items,

--- a/apps/api/src/modules/youtube/load-video-from-next.ts
+++ b/apps/api/src/modules/youtube/load-video-from-next.ts
@@ -1,5 +1,6 @@
 import { Client, LiveVideo, Video } from 'youtubei';
 
+import { captureRelatedParseFailure } from './safe-parse-related';
 import { postInnertube } from './innertube-post';
 import { asYoutubeRawData } from './youtubei-raw-data';
 
@@ -47,9 +48,13 @@ export async function loadVideoFromNextResponses(
         return { video: undefined, nextResponseData: nextResponse.data };
     }
 
-    const video = !playerData.playabilityStatus?.liveStreamability
-        ? new Video({ client }).load(data)
-        : new LiveVideo({ client }).load(data);
-
-    return { video, nextResponseData: nextResponse.data };
+    try {
+        const video = !playerData.playabilityStatus?.liveStreamability
+            ? new Video({ client }).load(data)
+            : new LiveVideo({ client }).load(data);
+        return { video, nextResponseData: nextResponse.data };
+    } catch (error) {
+        captureRelatedParseFailure(error);
+        return { video: undefined, nextResponseData: nextResponse.data };
+    }
 }

--- a/apps/api/src/modules/youtube/safe-parse-related.ts
+++ b/apps/api/src/modules/youtube/safe-parse-related.ts
@@ -1,0 +1,24 @@
+import { BaseVideoParser, type Client, type VideoCompact } from 'youtubei';
+
+import { captureUnexpected } from '@/sentry';
+
+import { asYoutubeRawData } from './youtubei-raw-data';
+
+export const RELATED_PARSE_CAPTURE = {
+    tags: { area: 'youtube', route: 'related', kind: 'parse' },
+    level: 'warning' as const,
+};
+
+export function captureRelatedParseFailure(error: unknown): void {
+    captureUnexpected(error, RELATED_PARSE_CAPTURE);
+}
+
+/** youtubei parseRelated throws on Innertube schema drift; related shelf should degrade. */
+export function safeParseRelated(raw: unknown, client: Client): VideoCompact[] {
+    try {
+        return BaseVideoParser.parseRelated(asYoutubeRawData(raw), client) as VideoCompact[];
+    } catch (error) {
+        captureRelatedParseFailure(error);
+        return [];
+    }
+}

--- a/apps/api/src/modules/youtube/safe-parse-related.ts
+++ b/apps/api/src/modules/youtube/safe-parse-related.ts
@@ -9,6 +9,13 @@ export const RELATED_PARSE_CAPTURE = {
     level: 'warning' as const,
 };
 
+type RelatedVideoShell = {
+    related?: {
+        items: unknown;
+        continuation?: string | null;
+    };
+};
+
 export function captureRelatedParseFailure(error: unknown): void {
     captureUnexpected(error, RELATED_PARSE_CAPTURE);
 }
@@ -21,4 +28,32 @@ export function safeParseRelated(raw: unknown, client: Client): VideoCompact[] {
         captureRelatedParseFailure(error);
         return [];
     }
+}
+
+/** youtubei parseContinuation throws on schema drift; pagination should stop, not 502. */
+export function safeParseContinuation(raw: unknown): string | null | undefined {
+    try {
+        return BaseVideoParser.parseContinuation(asYoutubeRawData(raw));
+    } catch (error) {
+        captureRelatedParseFailure(error);
+        return undefined;
+    }
+}
+
+/** Prefer the loaded video related shell; otherwise parse items and continuation independently. */
+export function resolveRelatedShelf(
+    video: RelatedVideoShell | undefined,
+    nextResponseData: unknown,
+    client: Client,
+): { items: VideoCompact[]; continuation: string | null | undefined } {
+    if (video?.related) {
+        return {
+            items: video.related.items as VideoCompact[],
+            continuation: video.related.continuation,
+        };
+    }
+    return {
+        items: safeParseRelated(nextResponseData, client),
+        continuation: safeParseContinuation(nextResponseData),
+    };
 }

--- a/apps/api/src/youtubei.ts
+++ b/apps/api/src/youtubei.ts
@@ -41,6 +41,7 @@ import {
     fetchSearchInitialPage,
 } from './modules/youtube/fetch-search-page';
 import { loadVideoFromNextResponses } from './modules/youtube/load-video-from-next';
+import { safeParseRelated } from './modules/youtube/safe-parse-related';
 import { prepareYoutubeVideos } from './modules/youtube/prepare-youtube-videos';
 import { resolvePlaylistDetails } from './modules/youtube/fetch-playlist-details-cached';
 import { getYoutubeiClient } from './modules/youtube/youtubei-client';
@@ -287,15 +288,19 @@ export const searchYoutubeiElysia = new Elysia({})
                     );
                     relatedMetadata = extractRendererMetadata(nextResponseData);
 
-                    if (video?.related) {
-                        newItems = collectUniqueNewItems(
-                            video.related.items as VideoCompact[],
-                            processedVideoIds,
-                        );
+                    const relatedItems = video?.related
+                        ? (video.related.items as VideoCompact[])
+                        : safeParseRelated(nextResponseData, youtubeiClient);
+                    const relatedContinuation = video?.related
+                        ? video.related.continuation
+                        : undefined;
+
+                    newItems = collectUniqueNewItems(relatedItems, processedVideoIds);
+                    if (relatedItems.length > 0 || relatedContinuation) {
                         results = createRelatedContinuationCache(
                             youtubeiClient,
-                            video.related.items as VideoCompact[],
-                            video.related.continuation,
+                            relatedItems,
+                            relatedContinuation,
                         );
                     }
                 }

--- a/apps/api/src/youtubei.ts
+++ b/apps/api/src/youtubei.ts
@@ -41,7 +41,7 @@ import {
     fetchSearchInitialPage,
 } from './modules/youtube/fetch-search-page';
 import { loadVideoFromNextResponses } from './modules/youtube/load-video-from-next';
-import { safeParseRelated } from './modules/youtube/safe-parse-related';
+import { resolveRelatedShelf } from './modules/youtube/safe-parse-related';
 import { prepareYoutubeVideos } from './modules/youtube/prepare-youtube-videos';
 import { resolvePlaylistDetails } from './modules/youtube/fetch-playlist-details-cached';
 import { getYoutubeiClient } from './modules/youtube/youtubei-client';
@@ -288,12 +288,8 @@ export const searchYoutubeiElysia = new Elysia({})
                     );
                     relatedMetadata = extractRendererMetadata(nextResponseData);
 
-                    const relatedItems = video?.related
-                        ? (video.related.items as VideoCompact[])
-                        : safeParseRelated(nextResponseData, youtubeiClient);
-                    const relatedContinuation = video?.related
-                        ? video.related.continuation
-                        : undefined;
+                    const { items: relatedItems, continuation: relatedContinuation } =
+                        resolveRelatedShelf(video, nextResponseData, youtubeiClient);
 
                     newItems = collectUniqueNewItems(relatedItems, processedVideoIds);
                     if (relatedItems.length > 0 || relatedContinuation) {

--- a/apps/api/tests/modules/youtube/load-video-from-next.test.ts
+++ b/apps/api/tests/modules/youtube/load-video-from-next.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Client } from 'youtubei';
+
+const { videoLoad, liveVideoLoad, postInnertube, captureUnexpected } = vi.hoisted(() => ({
+    videoLoad: vi.fn(),
+    liveVideoLoad: vi.fn(),
+    postInnertube: vi.fn(),
+    captureUnexpected: vi.fn(),
+}));
+
+vi.mock('youtubei', () => ({
+    Client: class {},
+    Video: class {
+        load = videoLoad;
+    },
+    LiveVideo: class {
+        load = liveVideoLoad;
+    },
+}));
+
+vi.mock('@/modules/youtube/innertube-post', () => ({
+    postInnertube,
+}));
+
+vi.mock('@/sentry', () => ({
+    captureUnexpected,
+}));
+
+import { loadVideoFromNextResponses } from '@/modules/youtube/load-video-from-next';
+
+const client = {} as Client;
+
+const nextPayload = {
+    data: {
+        contents: {
+            twoColumnWatchNextResults: {
+                results: {
+                    results: {
+                        contents: [{ videoPrimaryInfoRenderer: {} }],
+                    },
+                },
+            },
+        },
+    },
+};
+
+const playerPayload = {
+    data: {
+        playabilityStatus: { status: 'OK' },
+    },
+};
+
+describe('loadVideoFromNextResponses', () => {
+    beforeEach(() => {
+        videoLoad.mockReset();
+        liveVideoLoad.mockReset();
+        postInnertube.mockReset();
+        captureUnexpected.mockReset();
+        postInnertube.mockImplementation(async (_client: unknown, endpoint: string) =>
+            endpoint.includes('/next') ? nextPayload : playerPayload,
+        );
+    });
+
+    it('returns video: undefined and captures when Video.load throws', async () => {
+        const error = new TypeError("Cannot read properties of undefined (reading 'content')");
+        videoLoad.mockImplementation(() => {
+            throw error;
+        });
+
+        const result = await loadVideoFromNextResponses(client, 'dQw4w9WgXcQ');
+
+        expect(result.video).toBeUndefined();
+        expect(result.nextResponseData).toBe(nextPayload.data);
+        expect(captureUnexpected).toHaveBeenCalledWith(error, {
+            tags: { area: 'youtube', route: 'related', kind: 'parse' },
+            level: 'warning',
+        });
+    });
+
+    it('does not call Video.load when InnerTube contents are missing', async () => {
+        postInnertube.mockImplementation(async (_client: unknown, endpoint: string) =>
+            endpoint.includes('/next') ? { data: {} } : playerPayload,
+        );
+
+        const result = await loadVideoFromNextResponses(client, 'abc');
+
+        expect(result.video).toBeUndefined();
+        expect(videoLoad).not.toHaveBeenCalled();
+        expect(captureUnexpected).not.toHaveBeenCalled();
+    });
+});

--- a/apps/api/tests/modules/youtube/safe-parse-related.test.ts
+++ b/apps/api/tests/modules/youtube/safe-parse-related.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Client } from 'youtubei';
+
+const { parseRelated, captureUnexpected } = vi.hoisted(() => ({
+    parseRelated: vi.fn(),
+    captureUnexpected: vi.fn(),
+}));
+
+vi.mock('youtubei', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('youtubei')>();
+    return {
+        ...actual,
+        BaseVideoParser: {
+            ...actual.BaseVideoParser,
+            parseRelated,
+        },
+    };
+});
+
+vi.mock('@/sentry', () => ({
+    captureUnexpected,
+}));
+
+import { safeParseRelated } from '@/modules/youtube/safe-parse-related';
+
+const client = {} as Client;
+
+describe('safeParseRelated', () => {
+    beforeEach(() => {
+        parseRelated.mockReset();
+        captureUnexpected.mockReset();
+    });
+
+    it('returns parsed items when youtubei succeeds', () => {
+        const items = [{ id: 'abc' }];
+        parseRelated.mockReturnValue(items);
+
+        expect(safeParseRelated({ contents: {} }, client)).toBe(items);
+        expect(captureUnexpected).not.toHaveBeenCalled();
+    });
+
+    it('returns [] and captures when parseRelated throws', () => {
+        const error = new TypeError("Cannot read properties of undefined (reading '0')");
+        parseRelated.mockImplementation(() => {
+            throw error;
+        });
+
+        expect(safeParseRelated({ onResponseReceivedEndpoints: undefined }, client)).toEqual([]);
+        expect(captureUnexpected).toHaveBeenCalledWith(error, {
+            tags: { area: 'youtube', route: 'related', kind: 'parse' },
+            level: 'warning',
+        });
+    });
+});

--- a/apps/api/tests/modules/youtube/safe-parse-related.test.ts
+++ b/apps/api/tests/modules/youtube/safe-parse-related.test.ts
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Client } from 'youtubei';
 
-const { parseRelated, captureUnexpected } = vi.hoisted(() => ({
+const { parseRelated, parseContinuation, captureUnexpected } = vi.hoisted(() => ({
     parseRelated: vi.fn(),
+    parseContinuation: vi.fn(),
     captureUnexpected: vi.fn(),
 }));
 
@@ -13,6 +14,7 @@ vi.mock('youtubei', async (importOriginal) => {
         BaseVideoParser: {
             ...actual.BaseVideoParser,
             parseRelated,
+            parseContinuation,
         },
     };
 });
@@ -21,13 +23,18 @@ vi.mock('@/sentry', () => ({
     captureUnexpected,
 }));
 
-import { safeParseRelated } from '@/modules/youtube/safe-parse-related';
+import {
+    resolveRelatedShelf,
+    safeParseContinuation,
+    safeParseRelated,
+} from '@/modules/youtube/safe-parse-related';
 
 const client = {} as Client;
 
 describe('safeParseRelated', () => {
     beforeEach(() => {
         parseRelated.mockReset();
+        parseContinuation.mockReset();
         captureUnexpected.mockReset();
     });
 
@@ -50,5 +57,64 @@ describe('safeParseRelated', () => {
             tags: { area: 'youtube', route: 'related', kind: 'parse' },
             level: 'warning',
         });
+    });
+});
+
+describe('safeParseContinuation', () => {
+    beforeEach(() => {
+        parseContinuation.mockReset();
+        captureUnexpected.mockReset();
+    });
+
+    it('returns the token when youtubei succeeds', () => {
+        parseContinuation.mockReturnValue('next-token');
+
+        expect(safeParseContinuation({ contents: {} })).toBe('next-token');
+        expect(captureUnexpected).not.toHaveBeenCalled();
+    });
+
+    it('returns undefined and captures when parseContinuation throws', () => {
+        const error = new TypeError("Cannot read properties of undefined (reading 'token')");
+        parseContinuation.mockImplementation(() => {
+            throw error;
+        });
+
+        expect(safeParseContinuation({ contents: {} })).toBeUndefined();
+        expect(captureUnexpected).toHaveBeenCalledWith(error, {
+            tags: { area: 'youtube', route: 'related', kind: 'parse' },
+            level: 'warning',
+        });
+    });
+});
+
+describe('resolveRelatedShelf', () => {
+    beforeEach(() => {
+        parseRelated.mockReset();
+        parseContinuation.mockReset();
+        captureUnexpected.mockReset();
+    });
+
+    it('uses video.related when the loaded video has a related shell', () => {
+        const items = [{ id: 'from-video' }] as never;
+        const video = { related: { items, continuation: 'from-video' } };
+
+        expect(resolveRelatedShelf(video, { contents: {} }, client)).toEqual({
+            items,
+            continuation: 'from-video',
+        });
+        expect(parseRelated).not.toHaveBeenCalled();
+        expect(parseContinuation).not.toHaveBeenCalled();
+    });
+
+    it('keeps raw continuation when Video.load failed but related parse succeeds', () => {
+        const items = [{ id: 'from-raw' }];
+        parseRelated.mockReturnValue(items);
+        parseContinuation.mockReturnValue('raw-token');
+
+        expect(resolveRelatedShelf(undefined, { contents: {} }, client)).toEqual({
+            items,
+            continuation: 'raw-token',
+        });
+        expect(captureUnexpected).not.toHaveBeenCalled();
     });
 });

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -117,5 +117,7 @@
             "@vkara/youtube": ["../../packages/youtube/src/index.ts"],
             "@vkara/youtube/*": ["../../packages/youtube/src/*"]
         }
-    }
+    },
+    "include": ["src/**/*.ts", "tests/**/*.ts"],
+    "exclude": ["node_modules"]
 }

--- a/apps/web/public/tv-polyfills.js
+++ b/apps/web/public/tv-polyfills.js
@@ -1,6 +1,7 @@
 /**
- * Runtime polyfills for Samsung Smart TV browsers.
- * Baseline: Tizen 6.0 / 2021 ≈ Chrome 76.
+ * Runtime polyfills for Samsung Smart TV browsers and Safari 12 / iOS 12.
+ * Baseline: Tizen 6.0 / 2021 ≈ Chrome 76. Also shims Intl.PluralRules and
+ * MediaQueryList EventTarget when missing (no-op on modern engines).
  *
  * Loaded beforeInteractive from the root layout. Every shim is guarded, so on
  * modern browsers this is a no-op. Syntax downleveling of the app bundles
@@ -115,6 +116,47 @@
         window.structuredClone = function (value) {
             if (value === undefined) return undefined;
             return JSON.parse(JSON.stringify(value));
+        };
+    }
+
+    /* Intl.PluralRules (Safari 13). next-intl constructs this on first paint.
+       Cardinal tables are not required — returning 'other' unblocks iOS 12. */
+    if (typeof Intl !== 'undefined' && typeof Intl.PluralRules !== 'function') {
+        Intl.PluralRules = function PluralRules(locale) {
+            this.locale = locale == null ? 'en' : String(locale);
+        };
+        Intl.PluralRules.prototype.select = function select() {
+            return 'other';
+        };
+        Intl.PluralRules.prototype.resolvedOptions = function resolvedOptions() {
+            return { locale: this.locale, type: 'cardinal' };
+        };
+    }
+
+    /* MediaQueryList EventTarget (Safari 14). Older engines only have
+       addListener / removeListener. */
+    if (
+        typeof MediaQueryList !== 'undefined' &&
+        MediaQueryList.prototype &&
+        typeof MediaQueryList.prototype.addEventListener !== 'function' &&
+        typeof MediaQueryList.prototype.addListener === 'function'
+    ) {
+        MediaQueryList.prototype.addEventListener = function addEventListener(type, listener) {
+            if (type === 'change' && typeof listener === 'function') {
+                this.addListener(listener);
+            }
+        };
+        MediaQueryList.prototype.removeEventListener = function removeEventListener(
+            type,
+            listener,
+        ) {
+            if (
+                type === 'change' &&
+                typeof this.removeListener === 'function' &&
+                typeof listener === 'function'
+            ) {
+                this.removeListener(listener);
+            }
         };
     }
 })();

--- a/apps/web/src/app/[locale]/error.tsx
+++ b/apps/web/src/app/[locale]/error.tsx
@@ -2,11 +2,12 @@
 
 import { useErrorBoundaryRecovery } from '@/hooks/use-error-boundary-recovery';
 import { RecoveryShell } from '@/components/sentry/recovery-shell';
-import { useI18n } from '@/locales/client';
+import { documentRecoveryPhaseLabel } from '@/lib/recovery-phase-label';
 
 /**
  * Segment error boundary — reports to Sentry, then auto-recovers silently.
  * Soft `reset()` first; if the segment keeps crashing, navigates home.
+ * Must not call next-intl: Intl.PluralRules is missing on Safari 12.
  */
 export default function LocaleError({
     error,
@@ -15,15 +16,7 @@ export default function LocaleError({
     error: Error & { digest?: string };
     reset: () => void;
 }) {
-    const t = useI18n();
     const phase = useErrorBoundaryRecovery(error, reset);
 
-    const label =
-        phase === 'redirecting'
-            ? t('error.boundary.redirecting')
-            : phase === 'retrying'
-              ? t('error.boundary.retrying')
-              : t('error.boundary.reporting');
-
-    return <RecoveryShell phase={phase} label={label} />;
+    return <RecoveryShell phase={phase} label={documentRecoveryPhaseLabel(phase)} />;
 }

--- a/apps/web/src/components/sentry/app-error-boundary.tsx
+++ b/apps/web/src/components/sentry/app-error-boundary.tsx
@@ -5,7 +5,7 @@ import * as Sentry from '@sentry/nextjs';
 
 import { RecoveryShell } from '@/components/sentry/recovery-shell';
 import { useErrorBoundaryRecovery } from '@/hooks/use-error-boundary-recovery';
-import { useI18n } from '@/locales/client';
+import { documentRecoveryPhaseLabel } from '@/lib/recovery-phase-label';
 
 type FallbackProps = {
     error: unknown;
@@ -20,20 +20,16 @@ function toRecoverableError(error: unknown): Error & { digest?: string } {
 }
 
 function AutoRecoverFallback({ error, resetError }: FallbackProps) {
-    const t = useI18n();
     const recoverable = useMemo(() => toRecoverableError(error), [error]);
     const phase = useErrorBoundaryRecovery(recoverable, resetError, {
         boundaryTag: 'react_tree',
     });
+    const shellPhase = phase === 'reporting' ? 'retrying' : phase;
 
     return (
         <RecoveryShell
-            phase={phase === 'reporting' ? 'retrying' : phase}
-            label={
-                phase === 'redirecting'
-                    ? t('error.boundary.redirecting')
-                    : t('error.boundary.retrying')
-            }
+            phase={shellPhase}
+            label={documentRecoveryPhaseLabel(shellPhase)}
             className="flex min-h-[30vh] items-center justify-center px-6 py-10"
         />
     );
@@ -42,6 +38,7 @@ function AutoRecoverFallback({ error, resetError }: FallbackProps) {
 /**
  * Client-tree safety net under the locale layout.
  * Catches render errors that never reach `error.tsx`, reports to Sentry, auto-recovers.
+ * Must not call next-intl: Intl.PluralRules is missing on Safari 12.
  */
 export function AppErrorBoundary({ children }: { children: ReactNode }) {
     const renderFallback = useCallback(

--- a/apps/web/src/lib/recovery-phase-label.ts
+++ b/apps/web/src/lib/recovery-phase-label.ts
@@ -1,0 +1,26 @@
+export type RecoveryPhase = 'reporting' | 'retrying' | 'redirecting';
+
+const EN_LABELS: Record<RecoveryPhase, string> = {
+    reporting: 'Reporting the issue…',
+    retrying: 'Recovering automatically…',
+    redirecting: 'Taking you back…',
+};
+
+const VI_LABELS: Record<RecoveryPhase, string> = {
+    reporting: 'Đang ghi nhận lỗi…',
+    retrying: 'Đang tự khôi phục…',
+    redirecting: 'Đang đưa bạn về trang chính…',
+};
+
+/**
+ * Sr-only recovery copy without next-intl / Intl.PluralRules.
+ * Keep strings in sync with `error.boundary.*` in locales/en.ts and locales/vi.ts.
+ */
+export function recoveryPhaseLabel(phase: RecoveryPhase, lang?: string | null): string {
+    return (lang === 'vi' ? VI_LABELS : EN_LABELS)[phase];
+}
+
+export function documentRecoveryPhaseLabel(phase: RecoveryPhase): string {
+    const lang = typeof document !== 'undefined' ? document.documentElement.lang : undefined;
+    return recoveryPhaseLabel(phase, lang);
+}

--- a/apps/web/tests/lib/recovery-phase-label.test.ts
+++ b/apps/web/tests/lib/recovery-phase-label.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { recoveryPhaseLabel } from '@/lib/recovery-phase-label';
+
+describe('recoveryPhaseLabel', () => {
+    it('uses Vietnamese copy when lang is vi', () => {
+        expect(recoveryPhaseLabel('retrying', 'vi')).toBe('Đang tự khôi phục…');
+        expect(recoveryPhaseLabel('reporting', 'vi')).toBe('Đang ghi nhận lỗi…');
+        expect(recoveryPhaseLabel('redirecting', 'vi')).toBe('Đang đưa bạn về trang chính…');
+    });
+
+    it('uses English copy when lang is en', () => {
+        expect(recoveryPhaseLabel('retrying', 'en')).toBe('Recovering automatically…');
+        expect(recoveryPhaseLabel('reporting', 'en')).toBe('Reporting the issue…');
+        expect(recoveryPhaseLabel('redirecting', 'en')).toBe('Taking you back…');
+    });
+
+    it('falls back to English for missing or unknown lang', () => {
+        expect(recoveryPhaseLabel('retrying', undefined)).toBe('Recovering automatically…');
+        expect(recoveryPhaseLabel('retrying', '')).toBe('Recovering automatically…');
+        expect(recoveryPhaseLabel('retrying', 'fr')).toBe('Recovering automatically…');
+    });
+});

--- a/apps/web/tests/lib/tv-polyfills.test.ts
+++ b/apps/web/tests/lib/tv-polyfills.test.ts
@@ -1,0 +1,145 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const polyfillSource = fs.readFileSync(
+    path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../public/tv-polyfills.js'),
+    'utf8',
+);
+
+type MqlEventTarget = {
+    addEventListener(type: string, listener: () => void): void;
+    removeEventListener(type: string, listener: () => void): void;
+};
+
+const originalPluralRules = Intl.PluralRules;
+const originalWindow = (globalThis as { window?: Window & typeof globalThis }).window;
+
+function ensureWindow() {
+    if (typeof (globalThis as { window?: unknown }).window === 'undefined') {
+        (globalThis as { window: typeof globalThis }).window = globalThis;
+    }
+    const win = (globalThis as { window: { crypto?: Crypto } }).window;
+    if (!win.crypto) {
+        Object.defineProperty(win, 'crypto', {
+            configurable: true,
+            value: {
+                getRandomValues(bytes: Uint8Array) {
+                    for (let i = 0; i < bytes.length; i++) bytes[i] = i;
+                    return bytes;
+                },
+            },
+        });
+    }
+}
+
+function runPolyfills() {
+    ensureWindow();
+    vm.runInThisContext(polyfillSource, { filename: 'tv-polyfills.js' });
+}
+
+afterEach(() => {
+    Object.defineProperty(Intl, 'PluralRules', {
+        configurable: true,
+        writable: true,
+        value: originalPluralRules,
+    });
+    if (originalWindow === undefined) {
+        Reflect.deleteProperty(globalThis, 'window');
+    }
+    Reflect.deleteProperty(globalThis, 'MediaQueryList');
+});
+
+describe('tv-polyfills Intl.PluralRules', () => {
+    it('defines select() → other when PluralRules is missing', () => {
+        Object.defineProperty(Intl, 'PluralRules', {
+            configurable: true,
+            writable: true,
+            value: undefined,
+        });
+
+        runPolyfills();
+
+        expect(typeof Intl.PluralRules).toBe('function');
+        expect(new Intl.PluralRules('en').select(1)).toBe('other');
+        expect(new Intl.PluralRules('vi').select(2)).toBe('other');
+    });
+
+    it('does not replace a native PluralRules constructor', () => {
+        function NativePluralRules() {
+            /* marker */
+        }
+        NativePluralRules.prototype.select = () => 'one';
+        Object.defineProperty(Intl, 'PluralRules', {
+            configurable: true,
+            writable: true,
+            value: NativePluralRules,
+        });
+
+        runPolyfills();
+
+        expect(Intl.PluralRules).toBe(NativePluralRules);
+        expect(new Intl.PluralRules('en').select(1)).toBe('one');
+    });
+});
+
+describe('tv-polyfills MediaQueryList', () => {
+    it('forwards change listeners to addListener when addEventListener is missing', () => {
+        const added: unknown[] = [];
+        const removed: unknown[] = [];
+
+        class LegacyMediaQueryList {
+            addListener(listener: unknown) {
+                added.push(listener);
+            }
+            removeListener(listener: unknown) {
+                removed.push(listener);
+            }
+        }
+
+        Object.defineProperty(globalThis, 'MediaQueryList', {
+            configurable: true,
+            writable: true,
+            value: LegacyMediaQueryList,
+        });
+
+        runPolyfills();
+
+        const mq = new LegacyMediaQueryList() as LegacyMediaQueryList & MqlEventTarget;
+        const fn = () => undefined;
+        mq.addEventListener('change', fn);
+        mq.removeEventListener('change', fn);
+
+        expect(added).toEqual([fn]);
+        expect(removed).toEqual([fn]);
+    });
+
+    it('does not replace native addEventListener', () => {
+        const nativeAdd = function addEventListener() {
+            /* marker */
+        };
+
+        class ModernMediaQueryList {
+            addListener() {
+                throw new Error('addListener should not run');
+            }
+        }
+        (ModernMediaQueryList.prototype as ModernMediaQueryList & MqlEventTarget).addEventListener =
+            nativeAdd;
+
+        Object.defineProperty(globalThis, 'MediaQueryList', {
+            configurable: true,
+            writable: true,
+            value: ModernMediaQueryList,
+        });
+
+        runPolyfills();
+
+        expect(
+            (ModernMediaQueryList.prototype as ModernMediaQueryList & MqlEventTarget)
+                .addEventListener,
+        ).toBe(nativeAdd);
+    });
+});

--- a/openspec/changes/fix-sentry-first-party-crashes/.openspec.yaml
+++ b/openspec/changes/fix-sentry-first-party-crashes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-16

--- a/openspec/changes/fix-sentry-first-party-crashes/design.md
+++ b/openspec/changes/fix-sentry-first-party-crashes/design.md
@@ -60,7 +60,7 @@ Parser TypeErrors after a successful POST are schema drift → karaoke related s
 
 1. `loadVideoFromNextResponses` wraps `Video.load` / `LiveVideo.load` in try/catch. On throw: capture with tags `area=youtube`, `route=related`, `kind=parse`, `handled=yes`, level `warning`; return `{ video: undefined, nextResponseData }`.
 2. Shared `safeParseRelated(raw, client)` wraps `BaseVideoParser.parseRelated`. On throw: same capture; return `[]`. Continuation parse uses the same wrapper in `fetchRelatedContinuationPage`.
-3. `/related` initial path: if `video?.related` is missing after (1), call `safeParseRelated(nextResponseData, client)` so a failed `Video.load` can still yield a shelf. If that is also empty, return `200 { items: [], continuation: undefined }`.
+3. `/related` initial path: if `video?.related` is missing after (1), parse items and continuation independently from `nextResponseData` so a failed `Video.load` can still yield a shelf and a next-page token. If items are empty and continuation is missing, return `200 { items: [], continuation: undefined }`.
 4. Route-level catch remains for HTTP / unexpected failures only.
 
 **Rejected:** swallowing all `/related` errors into empty 200 (would hide real YouTube outages). **Rejected:** forking youtubei.

--- a/openspec/changes/fix-sentry-first-party-crashes/design.md
+++ b/openspec/changes/fix-sentry-first-party-crashes/design.md
@@ -1,0 +1,90 @@
+## Context
+
+Sentry production (org `vkara`) currently files two first-party crash clusters:
+
+1. **WEB-B / WEB-C** — Mobile Safari 12.1.2 / iOS 12.5.8. `next-intl` constructs `new Intl.PluralRules(locale)` (missing until Safari 13). The same session then hits `MediaQueryList.addEventListener is not a function` (`subscribeFinePointer` and `subscribeCoarsePointer` use the EventTarget API; Safari 14+). Locale `error.tsx` and `AppErrorBoundary` call `useI18n()`, so the recovery chrome re-throws the PluralRules crash. Replay + Seer confirm a white screen, not a third-party inject.
+2. **API-A / API-C** — `POST /related` wraps youtubei `Video.load` / `BaseVideoParser.parseRelated` in a route-level try/catch that maps **any** throw to `502 youtube_upstream_failed`. Innertube schema drift (`videoInfo.attributedDescription.content`, `onResponseReceivedEndpoints[0]`) is a parse TypeError after a successful InnerTube POST. Event count is the impact (proxy IP collapses users=1). Still firing.
+
+`tv-polyfills.js` already loads `beforeInteractive` from `apps/web/src/app/[locale]/layout.tsx` on **every** locale document (not only `/tv`). It is ES5, guarded, JS-API-only.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Stop Safari 12 / iOS 12 from white-screening on first paint (PluralRules + MediaQueryList).
+- Keep error recovery renderable when `next-intl` / `Intl` is the failing subsystem.
+- Return a usable related JSON body (`200`, possibly empty `items`) when youtubei parsers throw on schema drift; keep reporting those parse failures to Sentry.
+- Keep polyfills no-op on modern browsers; keep `/related` `502` for real InnerTube HTTP failures.
+
+**Non-Goals:**
+
+- Full CLDR `Intl.PluralRules` (cardinals, ordinals, `resolvedOptions`). `select()` → `'other'` is enough to stop the crash.
+- Raising the documented TV floor above Tizen 6.0 / Chrome 76; this change only extends the existing shim file.
+- Fixing Zalo inject (`WEB-8`/`WEB-9`), YouTube iframe SOP on Tizen (`WEB-A`), anonymous `videoElement.paused` (`WEB-7`), cron / Redis noise, reconnect-banner UX (not an exception).
+- Replacing youtubei or pinning Innertube response shapes.
+- Changing the public `/related` JSON schema.
+
+## Decisions
+
+### D1 — Extend `tv-polyfills.js` (no npm Intl polyfill)
+
+| | npm `intl-pluralrules` + app import | Guarded shims in `tv-polyfills.js` |
+|--|--|--|
+| Load order | After module graph; can race `next-intl` | `beforeInteractive`, before app JS |
+| Syntax | Modern package, needs downlevel | File is already ES5 |
+| Modern browsers | Extra bytes always | No-op when native exists |
+| Layout spec | Extra dependency | Matches `tv-chrome76-runtime` JS-API-only rule |
+
+**Chosen:** add two guarded blocks to `apps/web/public/tv-polyfills.js`.
+
+- `Intl.PluralRules`: constructor stores locale; `select()` returns `'other'`; `resolvedOptions()` returns `{ locale, type: 'cardinal' }` if called. Do not implement `selectRange`.
+- `MediaQueryList`: if `prototype.addEventListener` is missing and `addListener` exists, define `addEventListener` / `removeEventListener` that forward `type === 'change'` to `addListener` / `removeListener`. Ignore other event types. Do not replace native EventTarget methods.
+
+**Rejected:** wrapping every `matchMedia` call site with `addListener` fallback — two call sites today, easy to regress (`youtube/index.tsx`, `use-prefer-bottom-chrome.ts`). One prototype shim covers both and future subscribers.
+
+### D2 — Recovery labels without `next-intl`
+
+`RecoveryShell` labels are **sr-only**. `useI18n()` pulls in the same PluralRules path that just crashed.
+
+**Chosen:** a tiny helper (no `'use client'` requirement beyond callers) `recoveryPhaseLabel(phase, lang)` with a hardcoded `en` / `vi` map matching existing locale strings. Lang from `document.documentElement.lang` (layout already sets it) with `en` fallback. `error.tsx` and `AppErrorBoundary` MUST NOT import `@/locales/client`.
+
+**Rejected:** keeping `useI18n` behind try/catch (hooks cannot be optional). **Rejected:** English-only forever (Vietnamese remotes are the default locale).
+
+### D3 — Degrade related parse, do not 502 the shelf
+
+InnerTube HTTP (`postInnertube` → `client.http.post`) failing is a real upstream outage → keep `502 youtube_upstream_failed`.
+
+Parser TypeErrors after a successful POST are schema drift → karaoke related shelf should stay empty, player stays up.
+
+**Chosen:**
+
+1. `loadVideoFromNextResponses` wraps `Video.load` / `LiveVideo.load` in try/catch. On throw: capture with tags `area=youtube`, `route=related`, `kind=parse`, `handled=yes`, level `warning`; return `{ video: undefined, nextResponseData }`.
+2. Shared `safeParseRelated(raw, client)` wraps `BaseVideoParser.parseRelated`. On throw: same capture; return `[]`. Continuation parse uses the same wrapper in `fetchRelatedContinuationPage`.
+3. `/related` initial path: if `video?.related` is missing after (1), call `safeParseRelated(nextResponseData, client)` so a failed `Video.load` can still yield a shelf. If that is also empty, return `200 { items: [], continuation: undefined }`.
+4. Route-level catch remains for HTTP / unexpected failures only.
+
+**Rejected:** swallowing all `/related` errors into empty 200 (would hide real YouTube outages). **Rejected:** forking youtubei.
+
+### D4 — Tests target helpers, not the IIFE-as-app
+
+- Polyfills: vitest loads `public/tv-polyfills.js` against a stub `window` / `Intl` / `MediaQueryList` (delete native APIs, assert shims; restore natives, assert no-op).
+- Recovery labels: unit-test the helper (lang `vi` / `en` / unknown).
+- Related: unit-test `safeParseRelated` and `loadVideoFromNextResponses` with mocked youtubei `Video.load` / `BaseVideoParser.parseRelated` throws; assert empty result + that capture is invoked (spy). Do not require a live InnerTube.
+
+## Risks / Trade-offs
+
+- [Safari 12 still crashes on a different missing Intl API] → Mitigation: only PluralRules is in the WEB-B stack; `intl-locale-textinfo-polyfill` is already imported for `Intl.Locale`. If a new Intl crash appears, extend the same shim file.
+- [`select()` always `'other'` mis-pluralizes copy on iOS 12] → Acceptable: Vietnamese does not use English-style plurals; English fallback “other” is grammatical enough vs white screen.
+- [Empty related shelf looks like “no recommendations”] → Better than 502 killing the request; Sentry `kind=parse` keeps drift visible.
+- [New Sentry issue for `kind=parse`] → Intended: WEB/API crash issues should resolve; parse warnings are observability, not user-facing failures.
+- [Polyfill tests diverge from the public file] → Single source is the public ES5 file; tests execute that file.
+
+## Migration Plan
+
+- Deploy web + API together if possible; they are independent (web polyfill does not need API, API degrade does not need web).
+- Rollback: revert the two app changes; polyfill no-ops on modern browsers so rollback is safe.
+- After deploy: confirm `VKARA-WEB-B`, `VKARA-WEB-C`, `VKARA-API-A`, `VKARA-API-C` stop getting **unhandled / 502** events. Parse warnings may continue at low volume.
+
+## Open Questions
+
+None blocking implementation. Commit trailers `Fixes VKARA-WEB-B` / `WEB-C` / `API-A` / `API-C` when the user asks to commit.

--- a/openspec/changes/fix-sentry-first-party-crashes/proposal.md
+++ b/openspec/changes/fix-sentry-first-party-crashes/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Production Sentry is catching two first-party crashes that break karaoke for real users: (1) iOS 12 / Safari 12 white-screens on first paint because `next-intl` constructs `Intl.PluralRules` and the locale error boundary also calls i18n (`VKARA-WEB-B`, `VKARA-WEB-C`); (2) `POST /related` returns 502 when youtubei throws on Innertube schema drift (`VKARA-API-A`, `VKARA-API-C`). Both are still unresolved. This change fixes those crashes without adding features.
+
+## What Changes
+
+- Extend the existing guarded `tv-polyfills.js` (already loaded `beforeInteractive` on every locale layout) with `Intl.PluralRules` and `MediaQueryList.addEventListener` / `removeEventListener` fallbacks to the legacy `addListener` / `removeListener` APIs. Native implementations stay untouched.
+- Stop locale `error.tsx` and `AppErrorBoundary` from calling `useI18n()` so recovery chrome cannot re-throw the same Intl crash.
+- Treat youtubei `Video.load` / `parseRelated` failures on missing Innertube fields as a degraded related list (empty or partial `200`), not a `502 youtube_upstream_failed`. Still record the parse failure for Sentry.
+- Tests covering polyfill guards (or equivalent unit tests for the recovery label helper and related parse wrappers). Commit messages reference `Fixes VKARA-WEB-B`, `Fixes VKARA-WEB-C`, `Fixes VKARA-API-A`, `Fixes VKARA-API-C`.
+
+## Capabilities
+
+### New Capabilities
+
+- `youtube-related-parse-resilience`: `POST /related` survives Innertube payload shape changes in youtubei parsers; callers get a list (possibly empty) instead of a hard upstream 502 for schema-drift TypeErrors.
+- `error-boundary-without-intl`: Next.js / React error recovery UI must render without `next-intl` / `Intl.PluralRules` so the safety net works on Safari 12.
+
+### Modified Capabilities
+
+- `tv-chrome76-runtime`: Runtime JS polyfill script MUST also cover Safari 12 / iOS 12 gaps observed in production (`Intl.PluralRules`, `MediaQueryList` event-target methods). Script remains JS-API-only and no-op when native APIs exist.
+
+## Impact
+
+- `apps/web/public/tv-polyfills.js`, locale `error.tsx`, `app-error-boundary.tsx`, possibly a tiny recovery-label helper.
+- `apps/api/src/modules/youtube/load-video-from-next.ts`, `fetch-related-page.ts`, and the `/related` handler in `youtubei.ts`.
+- Tests under `apps/web` and `apps/api`. Public HTTP contract for `/related` stays the same JSON shape; only the 502-on-parse-crash behavior changes.
+- Sentry issues `VKARA-WEB-B`, `VKARA-WEB-C`, `VKARA-API-A`, `VKARA-API-C` should stop recurring after deploy. Out of scope: Zalo inject (`WEB-8`/`WEB-9`), YouTube iframe SOP (`WEB-A`), cron noise, reconnect-banner UX (not an exception).

--- a/openspec/changes/fix-sentry-first-party-crashes/specs/error-boundary-without-intl/spec.md
+++ b/openspec/changes/fix-sentry-first-party-crashes/specs/error-boundary-without-intl/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Recovery chrome does not call next-intl
+Locale `error.tsx` and `AppErrorBoundary` MUST render `RecoveryShell` without importing or calling `useI18n` / `next-intl`. Screen-reader phase labels MUST come from a helper that maps recovery phase plus document language (`en` / `vi`, default `en`) and MUST NOT construct `Intl.PluralRules`.
+
+#### Scenario: Fallback renders without i18n hooks
+- **WHEN** the locale error boundary or React error boundary fallback renders
+- **THEN** it does not call `useI18n`
+- **AND** `RecoveryShell` still receives a non-empty sr-only label for the current phase
+
+#### Scenario: Vietnamese document language
+- **WHEN** `document.documentElement.lang` is `vi`
+- **AND** the recovery phase is `retrying`
+- **THEN** the label MUST match the Vietnamese retrying copy already used in product locales
+
+#### Scenario: Unknown language falls back to English
+- **WHEN** document language is missing or not `vi`
+- **THEN** the label MUST use the English recovery copy

--- a/openspec/changes/fix-sentry-first-party-crashes/specs/tv-chrome76-runtime/spec.md
+++ b/openspec/changes/fix-sentry-first-party-crashes/specs/tv-chrome76-runtime/spec.md
@@ -1,0 +1,39 @@
+## MODIFIED Requirements
+
+### Requirement: Runtime polyfills load before app JS
+The locale root layout SHALL load a guarded `tv-polyfills` script `beforeInteractive` so APIs required by the client that are missing on Chrome 76 and on Safari 12 / iOS 12 (including at least `String.prototype.replaceAll`, the post-Chrome-85 shims already used by the chrome85 stack, `Intl.PluralRules`, and `MediaQueryList` event-target methods) are available before application modules run. On modern browsers the shims MUST be no-ops when the native API exists. The script MUST remain JS-API-only (no layout/CSS polyfills).
+
+#### Scenario: Polyfill script is present on TV route
+- **WHEN** a client loads `/tv` (or a localized `/tv`)
+- **THEN** the polyfill script is included before interactive application code
+
+#### Scenario: Polyfill script is present on remote locale routes
+- **WHEN** a client loads a locale document that is not `/tv` (for example `/` or `/vi`)
+- **THEN** the same polyfill script is included before interactive application code
+
+## ADDED Requirements
+
+### Requirement: Intl.PluralRules shim when missing
+When `Intl.PluralRules` is absent, `tv-polyfills.js` SHALL define a constructor such that `new Intl.PluralRules(locale).select(n)` returns `'other'` for any numeric `n` and does not throw. When `Intl.PluralRules` is already a function, the script MUST NOT replace it.
+
+#### Scenario: Safari 12 PluralRules gap
+- **WHEN** the polyfill script runs in an environment with no `Intl.PluralRules`
+- **THEN** `new Intl.PluralRules('en').select(1)` returns `'other'`
+- **AND** `new Intl.PluralRules('vi').select(2)` returns `'other'`
+
+#### Scenario: Native PluralRules untouched
+- **WHEN** the polyfill script runs where `Intl.PluralRules` already exists
+- **THEN** the native constructor identity is unchanged
+
+### Requirement: MediaQueryList EventTarget shim when missing
+When `MediaQueryList.prototype.addEventListener` is not a function and `addListener` exists, `tv-polyfills.js` SHALL define `addEventListener` and `removeEventListener` that forward `change` listeners to `addListener` / `removeListener`. When `addEventListener` already exists, the script MUST NOT replace it.
+
+#### Scenario: Legacy MediaQueryList
+- **WHEN** a `MediaQueryList` has `addListener` but no `addEventListener`
+- **AND** the polyfill script has run
+- **THEN** `mq.addEventListener('change', fn)` calls `addListener(fn)`
+- **AND** `mq.removeEventListener('change', fn)` calls `removeListener(fn)`
+
+#### Scenario: Native MediaQueryList untouched
+- **WHEN** `MediaQueryList.prototype.addEventListener` is already a function
+- **THEN** the polyfill script does not replace that method

--- a/openspec/changes/fix-sentry-first-party-crashes/specs/youtube-related-parse-resilience/spec.md
+++ b/openspec/changes/fix-sentry-first-party-crashes/specs/youtube-related-parse-resilience/spec.md
@@ -19,6 +19,12 @@ When InnerTube `next`/`player` HTTP succeeds but youtubei `Video.load`, `LiveVid
 - **WHEN** InnerTube HTTP for `/related` throws (network or non-success transport)
 - **THEN** `POST /related` MAY still return `502 youtube_upstream_failed`
 
+#### Scenario: Continuation kept when Video.load fails but related parse succeeds
+- **WHEN** `loadVideoFromNextResponses` returns `video: undefined`
+- **AND** related items parse from `nextResponseData`
+- **AND** continuation parse from `nextResponseData` returns a token
+- **THEN** the related response MUST include that continuation so pagination can continue
+
 ### Requirement: Parse failures remain visible in Sentry
 Each swallowed youtubei parse throw on the related path MUST be reported via `captureUnexpected` with tags `area=youtube`, `route=related`, `kind=parse`, and level `warning`.
 

--- a/openspec/changes/fix-sentry-first-party-crashes/specs/youtube-related-parse-resilience/spec.md
+++ b/openspec/changes/fix-sentry-first-party-crashes/specs/youtube-related-parse-resilience/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Related parse failures do not 502
+When InnerTube `next`/`player` HTTP succeeds but youtubei `Video.load`, `LiveVideo.load`, or `BaseVideoParser.parseRelated` throws (including missing `attributedDescription.content` or `onResponseReceivedEndpoints[0]`), `POST /related` MUST NOT return `502 youtube_upstream_failed`. The handler MUST return HTTP 200 with `{ items, continuation }` where `items` MAY be empty and `continuation` MAY be omitted.
+
+#### Scenario: Video.load throws on schema drift
+- **WHEN** `loadVideoFromNextResponses` receives a successful InnerTube payload
+- **AND** `Video.load` / `LiveVideo.load` throws
+- **THEN** the function MUST return `video: undefined` plus the raw `nextResponseData`
+- **AND** MUST NOT rethrow that parse error
+
+#### Scenario: parseRelated throws on continuation
+- **WHEN** `fetchRelatedContinuationPage` receives a successful InnerTube continuation payload
+- **AND** `BaseVideoParser.parseRelated` throws
+- **THEN** the page result MUST have `items` as an empty array
+- **AND** MUST NOT rethrow that parse error
+
+#### Scenario: Related HTTP still 502 on transport failure
+- **WHEN** InnerTube HTTP for `/related` throws (network or non-success transport)
+- **THEN** `POST /related` MAY still return `502 youtube_upstream_failed`
+
+### Requirement: Parse failures remain visible in Sentry
+Each swallowed youtubei parse throw on the related path MUST be reported via `captureUnexpected` with tags `area=youtube`, `route=related`, `kind=parse`, and level `warning`.
+
+#### Scenario: Capture on Video.load throw
+- **WHEN** `Video.load` throws inside `loadVideoFromNextResponses`
+- **THEN** `captureUnexpected` is invoked with `kind=parse`
+
+#### Scenario: Capture on parseRelated throw
+- **WHEN** `safeParseRelated` catches `BaseVideoParser.parseRelated`
+- **THEN** `captureUnexpected` is invoked with `kind=parse`

--- a/openspec/changes/fix-sentry-first-party-crashes/tasks.md
+++ b/openspec/changes/fix-sentry-first-party-crashes/tasks.md
@@ -1,0 +1,21 @@
+## 1. Safari 12 polyfills
+
+- [x] 1.1 Add vitest that loads `apps/web/public/tv-polyfills.js` against a stub window: missing `Intl.PluralRules` and `MediaQueryList.addEventListener` get shims; native implementations stay untouched
+- [x] 1.2 Add guarded ES5 `Intl.PluralRules` (`select` → `'other'`) and `MediaQueryList` EventTarget forwarders to `tv-polyfills.js`
+
+## 2. Error recovery without next-intl
+
+- [x] 2.1 Add vitest for `recoveryPhaseLabel(phase, lang)` covering `vi`, `en`, and unknown lang
+- [x] 2.2 Implement the helper with hardcoded en/vi strings matching product locales; no `next-intl` import
+- [x] 2.3 Switch `error.tsx` and `AppErrorBoundary` to the helper; remove `useI18n`
+
+## 3. Related parse resilience
+
+- [x] 3.1 Add vitest: `safeParseRelated` returns `[]` and captures when `parseRelated` throws; `loadVideoFromNextResponses` returns `video: undefined` and captures when `Video.load` throws
+- [x] 3.2 Implement `safeParseRelated` and wrap `Video`/`LiveVideo.load` in `loadVideoFromNextResponses` with `captureUnexpected` tags `kind=parse`
+- [x] 3.3 Use `safeParseRelated` in `fetchRelatedContinuationPage` and as fallback when `video.related` is missing after a successful InnerTube POST; keep route-level `502` only for transport failures
+
+## 4. Verify
+
+- [x] 4.1 Run `apps/web` and `apps/api` tests for the new files and confirm they pass
+- [x] 4.2 Run `openspec validate --change fix-sentry-first-party-crashes` and fix any schema issues


### PR DESCRIPTION
## Summary

Fixes four unresolved first-party production crashes tracked in Sentry. On **web**, Safari 12 / iOS 12 no longer white-screens on first paint, and error recovery UI no longer re-throws via `next-intl`. On **API**, YouTube Innertube schema drift no longer turns the related shelf into a 502.

**Sentry:** Fixes VKARA-WEB-B, VKARA-WEB-C, VKARA-API-A, VKARA-API-C

## Problem

### Web (VKARA-WEB-B / VKARA-WEB-C)

- `next-intl` constructs `Intl.PluralRules` on first paint; Safari 12 lacks this API → white screen.
- Locale `error.tsx` and `AppErrorBoundary` called `useI18n()` on the crash path → recovery UI could throw the same Intl error again (error-on-error loop).

### API (VKARA-API-A / VKARA-API-C)

- `youtubei` `Video.load` / `BaseVideoParser.parseRelated` throw `TypeError` when Innertube payload shape drifts.
- `/related` surfaced these as `502 youtube_upstream_failed` instead of degrading gracefully.

## Changes

### Web

- **`apps/web/public/tv-polyfills.js`**
  - Shim `Intl.PluralRules` (returns `'other'`) for Safari 12.
  - Forward `MediaQueryList.addEventListener` / `removeEventListener` to legacy `addListener` / `removeListener`.
  - All shims guarded - no-op on modern engines (same pattern as existing TV polyfills).

- **`apps/web/src/lib/recovery-phase-label.ts`**
  - Hardcoded en/vi labels for recovery phases (`reporting`, `retrying`, `redirecting`).
  - Reads locale from `document.documentElement.lang` - no `next-intl` / `Intl.PluralRules`.

- **`error.tsx` + `app-error-boundary.tsx`**
  - Stop calling `useI18n()` on the crash path; use `documentRecoveryPhaseLabel()` instead.

### API

- **`apps/api/src/modules/youtube/safe-parse-related.ts`** (new)
  - `safeParseRelated()` - returns `[]` on parse failure.
  - `captureRelatedParseFailure()` - Sentry warning with tags `{ area: youtube, route: related, kind: parse }`.

- **`load-video-from-next.ts`**
  - Wrap `Video.load` / `LiveVideo.load` in try/catch; return `video: undefined` on failure.

- **`fetch-related-page.ts` + `youtubei.ts`**
  - Use safe parse for related items and continuation.
  - Fall back to raw `nextResponseData` when `video.related` is missing after load failure.
  - Callers still get `200` with empty/partial list instead of 502.

### Tests

- `apps/web/tests/lib/tv-polyfills.test.ts` - polyfill guards via vm
- `apps/web/tests/lib/recovery-phase-label.test.ts` - en/vi/fallback labels
- `apps/api/tests/modules/youtube/safe-parse-related.test.ts`
- `apps/api/tests/modules/youtube/load-video-from-next.test.ts`

## Test plan

- [x] `pnpm --filter web test` - polyfill + recovery label tests pass
- [x] `pnpm --filter api test` - safe parse + load-video tests pass
- [x] Local web on Safari 12 / iOS 12 simulator (or BrowserStack): app loads without white screen
- [x] Trigger segment error locally: recovery shell shows en/vi copy without crashing again
- [x] `POST /related` with a video that previously 502'd: returns `200` with empty or partial list; Sentry warning logged (not 502)
- [x] Related shelf still populates normally for healthy Innertube responses
- [x] Deploy to staging; confirm VKARA-WEB-B/C and VKARA-API-A/C stop recurring in Sentry

## Out of scope

- Zalo inject noise (WEB-8/WEB-9)
- YouTube iframe SOP (WEB-A)
- Cron noise, reconnect-banner UX

## Summary by Sourcery

Harden Safari error recovery and YouTube related-content handling against first-party runtime and upstream schema failures.

Bug Fixes:
- Prevent first paint and error-recovery crashes on Safari 12 and iOS 12 by adding guarded compatibility shims and removing i18n dependencies from recovery fallbacks.
- Make YouTube related-content requests degrade to empty or partial results instead of returning 502 responses when youtubei parsing encounters schema drift, while preserving Sentry visibility for parse failures.

Enhancements:
- Add locale-aware, dependency-free recovery labels for English and Vietnamese error states.
- Retain related-content continuation data when video loading fails but raw response parsing remains usable.

Build:
- Expand the API TypeScript project configuration to include source and test files.

Tests:
- Add coverage for Safari compatibility shims, recovery labels, safe related-content parsing, and video-load failure handling.

Chores:
- Document the crash-resilience behavior and requirements in the OpenSpec change proposal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved related-video loading so parsing errors return partial or empty results instead of failing successful requests.
  * Added error reporting for related-content and video parsing failures while preserving transport-error handling.
  * Improved error recovery messaging for supported languages and older Safari/iOS versions.

* **Compatibility**
  * Added safeguards for legacy browser and TV environments, including missing internationalization and media-query APIs.

* **Tests**
  * Added coverage for parsing fallbacks, recovery labels, and browser compatibility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->